### PR TITLE
Terraform version 0.12

### DIFF
--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -1,9 +1,15 @@
 variable "alb_dimension_id" {}
+
 variable "target_group_dimension_id" {}
+
 variable "app_environment" {}
+
 variable "targets_name" {}
+
 variable "server_min_instances" {}
+
 variable "sns_monitoring_topic_arn" {}
+
 variable "low_priority_sns_monitoring_topic_arn" {}
 
 resource "aws_cloudwatch_metric_alarm" "healthy_hosts_low_too_long" {
@@ -11,18 +17,18 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_low_too_long" {
   alarm_description = "Less than the desired number of healthy ${var.targets_name} hosts behind the ALB for too long"
   namespace = "AWS/ApplicationELB"
   dimensions = {
-    "LoadBalancer" = "${var.alb_dimension_id}"
-    "TargetGroup" = "${var.target_group_dimension_id}"
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = "${var.server_min_instances}"
+  threshold = var.server_min_instances
   unit = "Count"
   period = "300"
   statistic = "Average"
   evaluation_periods = "5"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -31,18 +37,18 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   alarm_description = "Significantly less than the desired number of healthy ${var.targets_name} hosts behind the ALB"
   namespace = "AWS/ApplicationELB"
   dimensions = {
-    "LoadBalancer" = "${var.alb_dimension_id}"
-    "TargetGroup" = "${var.target_group_dimension_id}"
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = "${var.server_min_instances - 1}"
+  threshold = var.server_min_instances - 1
   unit = "Count"
   period = "60"
   statistic = "Average"
   evaluation_periods = "3"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -51,8 +57,8 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time" {
   alarm_description = "High latency from backend servers"
   namespace = "AWS/ApplicationELB"
   dimensions = {
-    "LoadBalancer" = "${var.alb_dimension_id}"
-    "TargetGroup" = "${var.target_group_dimension_id}"
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
   }
   metric_name = "TargetResponseTime"
   comparison_operator = "GreaterThanThreshold"
@@ -61,8 +67,8 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time" {
   period = "300"
   statistic = "Average"
   evaluation_periods = "3"
-  alarm_actions = ["${var.low_priority_sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.low_priority_sns_monitoring_topic_arn}"]
+  alarm_actions = [var.low_priority_sns_monitoring_topic_arn]
+  ok_actions = [var.low_priority_sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -71,8 +77,8 @@ resource "aws_cloudwatch_metric_alarm" "rejected_connection_count" {
   alarm_description = "Connections rejected for lack of a healthy target"
   namespace = "AWS/ApplicationELB"
   dimensions = {
-    "LoadBalancer" = "${var.alb_dimension_id}"
-    "TargetGroup" = "${var.target_group_dimension_id}"
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
   }
   metric_name = "RejectedConnectionCount"
   comparison_operator = "GreaterThanThreshold"
@@ -81,8 +87,8 @@ resource "aws_cloudwatch_metric_alarm" "rejected_connection_count" {
   period = "60"
   statistic = "Sum"
   evaluation_periods = "1"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
   treat_missing_data = "notBreaching"
 }

--- a/cloudwatch_alb_target_group/versions.tf
+++ b/cloudwatch_alb_target_group/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/cloudwatch_elb/main.tf
+++ b/cloudwatch_elb/main.tf
@@ -1,7 +1,11 @@
 variable "alarm_name_prefix" {}
+
 variable "lb_name" {}
+
 variable "server_min_instances" {}
+
 variable "sns_monitoring_topic_arn" {}
+
 variable "low_priority_sns_monitoring_topic_arn" {}
 
 resource "aws_cloudwatch_metric_alarm" "healthy_hosts_low_too_long" {
@@ -9,17 +13,17 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_low_too_long" {
   alarm_description = "Less than the desired number of healthy hosts behind this ELB for too long"
   namespace = "AWS/ELB"
   dimensions = {
-    "LoadBalancerName" = "${var.lb_name}"
+    "LoadBalancerName" = var.lb_name
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = "${var.server_min_instances}"
+  threshold = var.server_min_instances
   unit = "Count"
   period = "300"
   statistic = "Average"
   evaluation_periods = "5"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -28,17 +32,17 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   alarm_description = "Significantly less than the desired number of healthy hosts behind this ELB"
   namespace = "AWS/ELB"
   dimensions = {
-    "LoadBalancerName" = "${var.lb_name}"
+    "LoadBalancerName" = var.lb_name
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = "${var.server_min_instances - 1}"
+  threshold = var.server_min_instances - 1
   unit = "Count"
   period = "60"
   statistic = "Average"
   evaluation_periods = "3"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -47,7 +51,7 @@ resource "aws_cloudwatch_metric_alarm" "latency" {
   alarm_description = "High latency from backend servers"
   namespace = "AWS/ELB"
   dimensions = {
-    "LoadBalancerName" = "${var.lb_name}"
+    "LoadBalancerName" = var.lb_name
   }
   metric_name = "Latency"
   comparison_operator = "GreaterThanThreshold"
@@ -56,8 +60,8 @@ resource "aws_cloudwatch_metric_alarm" "latency" {
   period = "300"
   statistic = "Average"
   evaluation_periods = "3"
-  alarm_actions = ["${var.low_priority_sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.low_priority_sns_monitoring_topic_arn}"]
+  alarm_actions = [var.low_priority_sns_monitoring_topic_arn]
+  ok_actions = [var.low_priority_sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -66,7 +70,7 @@ resource "aws_cloudwatch_metric_alarm" "surge_queue" {
   alarm_description = "ELB has too many requests waiting for a backend instance"
   namespace = "AWS/ELB"
   dimensions = {
-    "LoadBalancerName" = "${var.lb_name}"
+    "LoadBalancerName" = var.lb_name
   }
   metric_name = "SurgeQueueLength"
   comparison_operator = "GreaterThanThreshold"
@@ -75,8 +79,8 @@ resource "aws_cloudwatch_metric_alarm" "surge_queue" {
   period = "60"
   statistic = "Maximum"
   evaluation_periods = "1"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }
 
@@ -85,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "spillover" {
   alarm_description = "ELB is rejecting requests due to lack of capacity"
   namespace = "AWS/ELB"
   dimensions = {
-    "LoadBalancerName" = "${var.lb_name}"
+    "LoadBalancerName" = var.lb_name
   }
   metric_name = "SpilloverCount"
   comparison_operator = "GreaterThanThreshold"
@@ -94,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "spillover" {
   period = "60"
   statistic = "Sum"
   evaluation_periods = "1"
-  alarm_actions = ["${var.sns_monitoring_topic_arn}"]
-  ok_actions = ["${var.sns_monitoring_topic_arn}"]
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
 }

--- a/cloudwatch_elb/versions.tf
+++ b/cloudwatch_elb/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/iam_policy_cloudwatch/main.tf
+++ b/iam_policy_cloudwatch/main.tf
@@ -1,6 +1,8 @@
 # role names as string separated by ','
 variable "roles" {}
+
 variable "env" {}
+
 variable "app" {}
 
 resource "aws_iam_policy" "manage_cloudwatch" {
@@ -25,10 +27,11 @@ resource "aws_iam_policy" "manage_cloudwatch" {
     ]
 }
 POLICY
+
 }
 
 resource "aws_iam_policy_attachment" "manage_cloudwatch" {
   name = "${var.app}-${var.env}-manage-cloudwatch"
-  roles = ["${split(",", var.roles)}"]
-  policy_arn = "${aws_iam_policy.manage_cloudwatch.arn}"
+  roles = split(",", var.roles)
+  policy_arn = aws_iam_policy.manage_cloudwatch.arn
 }

--- a/iam_policy_cloudwatch/versions.tf
+++ b/iam_policy_cloudwatch/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/iam_policy_describe_ec2/main.tf
+++ b/iam_policy_describe_ec2/main.tf
@@ -1,6 +1,8 @@
 # role names as string separated by ','
 variable "roles" {}
+
 variable "env" {}
+
 variable "app" {}
 
 resource "aws_iam_policy" "describe_ec2" {
@@ -23,10 +25,11 @@ resource "aws_iam_policy" "describe_ec2" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_iam_policy_attachment" "describe_ec2" {
   name = "${var.app}-${var.env}-describe-ec2"
-  roles = ["${split(",", var.roles)}"]
-  policy_arn = "${aws_iam_policy.describe_ec2.arn}"
+  roles = split(",", var.roles)
+  policy_arn = aws_iam_policy.describe_ec2.arn
 }

--- a/iam_policy_describe_ec2/versions.tf
+++ b/iam_policy_describe_ec2/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/openvpn/main.tf
+++ b/openvpn/main.tf
@@ -5,81 +5,104 @@
 # https://raw.githubusercontent.com/hashicorp/best-practices/master/terraform/modules/aws/network/openvpn/openvpn.tf
 #--------------------------------------------------------------
 
-variable "name"               { default = "openvpn" }
-variable "vpc_id"             { }
-variable "vpc_cidr"           { }
-variable "public_subnet_ids"  { }
-variable "ssl_cert"           { }
-variable "ssl_key"            { }
-variable "ssh_username"       { }
-variable "ami"                { default = "ami-5fe36434" }
-variable "instance_type"      { }
-variable "openvpn_user"       { }
-variable "openvpn_admin_user" { }
-variable "openvpn_admin_pw"   { }
-variable "vpn_cidr"           { }
-variable "route_zone_id"      { }
-variable "route_zone_name"    { }
-variable "app_environment"    { }
-variable "ssh_cidr_block"     { }
+variable "name" {
+  default = "openvpn"
+}
+
+variable "vpc_id" {}
+
+variable "vpc_cidr" {}
+
+variable "public_subnet_ids" {}
+
+variable "ssl_cert" {}
+
+variable "ssl_key" {}
+
+variable "ssh_username" {}
+
+variable "ami" {
+  default = "ami-5fe36434"
+}
+
+variable "instance_type" {}
+
+variable "openvpn_user" {}
+
+variable "openvpn_admin_user" {}
+
+variable "openvpn_admin_pw" {}
+
+variable "vpn_cidr" {}
+
+variable "route_zone_id" {}
+
+variable "route_zone_name" {}
+
+variable "app_environment" {}
+
+variable "ssh_cidr_block" {}
+
 variable "public_hosted_zone_id" {}
 
 resource "aws_security_group" "openvpn" {
-  name   = "${var.name}"
-  vpc_id = "${var.vpc_id}"
+  name = var.name
+  vpc_id = var.vpc_id
   description = "OpenVPN security group"
 
-  tags { Name = "${var.name}" }
+  tags = {
+    Name = var.name
+  }
 
   ingress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["${var.vpc_cidr}"]
+    protocol = -1
+    from_port = 0
+    to_port = 0
+    cidr_blocks = [var.vpc_cidr]
   }
 
   # For OpenVPN Client Web Server & Admin Web UI
   ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
+    protocol = "tcp"
+    from_port = 443
+    to_port = 443
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # For SSH
   ingress {
-    protocol    = "tcp"
-    from_port   = 22
-    to_port     = 22
-    cidr_blocks = ["${var.ssh_cidr_block}"]
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = [var.ssh_cidr_block]
   }
 
   ingress {
-    protocol    = "udp"
-    from_port   = 1194
-    to_port     = 1194
+    protocol = "udp"
+    from_port = 1194
+    to_port = 1194
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
+    protocol = -1
+    from_port = 0
+    to_port = 0
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_instance" "openvpn" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  subnet_id     = "${element(split(",", var.public_subnet_ids), count.index)}"
+  ami = var.ami
+  instance_type = var.instance_type
+  subnet_id = element(split(",", var.public_subnet_ids), count.index)
   associate_public_ip_address = true
-  vpc_security_group_ids = ["${aws_security_group.openvpn.id}"]
-  iam_instance_profile = "${aws_iam_instance_profile.vpn.name}"
+  vpc_security_group_ids = [aws_security_group.openvpn.id]
+  iam_instance_profile = aws_iam_instance_profile.vpn.name
 
-  tags {
-    Name = "${var.name}"
-    environment = "${var.app_environment}"
+  tags = {
+    Name = var.name
+    environment = var.app_environment
     kind = "vpn"
     role = "app"
   }
@@ -91,10 +114,12 @@ admin_user=${var.openvpn_admin_user}
 admin_pw=${var.openvpn_admin_pw}
 USERDATA
 
+
   provisioner "remote-exec" {
     connection {
-      user         = "${var.ssh_username}"
-      host         = "${aws_instance.openvpn.public_ip}"
+      type = "ssh"
+      user = var.ssh_username
+      host = aws_instance.openvpn.public_ip
     }
 
     inline = [
@@ -118,7 +143,6 @@ USERDATA
   }
 }
 
-
 resource "aws_iam_role" "vpn" {
   name = "vpn-${var.app_environment}"
   assume_role_policy = <<POLICY
@@ -136,24 +160,25 @@ resource "aws_iam_role" "vpn" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_iam_instance_profile" "vpn" {
   name = "vpn-${var.app_environment}"
-  roles = ["${aws_iam_role.vpn.name}"]
+  roles = [aws_iam_role.vpn.name]
 }
 
 module "iam_describe_ec2" {
   source = "github.com/controlshift/terraform-modules//iam_policy_describe_ec2"
-  roles = "${aws_iam_role.vpn.name}"
-  env = "${var.app_environment}"
+  roles = aws_iam_role.vpn.name
+  env = var.app_environment
   app = "vpn"
 }
 
 module "iam_manage_cloudwatch" {
   source = "github.com/controlshift/terraform-modules//iam_policy_cloudwatch"
-  roles = "${aws_iam_role.vpn.name}"
-  env = "${var.app_environment}"
+  roles = aws_iam_role.vpn.name
+  env = var.app_environment
   app = "vpn"
 }
 
@@ -186,22 +211,31 @@ resource "aws_iam_policy" "vpn_domain" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_iam_policy_attachment" "vpn_domains_for_hostnames" {
   name = "vpn-${var.app_environment}-manage-domains-for-hostnames"
-  roles = ["${aws_iam_role.vpn.name}"]
-  policy_arn = "${aws_iam_policy.vpn_domain.arn}"
+  roles = [aws_iam_role.vpn.name]
+  policy_arn = aws_iam_policy.vpn_domain.arn
 }
 
 resource "aws_route53_record" "openvpn" {
-  zone_id = "${var.route_zone_id}"
-  name    = "app.${var.route_zone_name}"
-  type    = "A"
-  ttl     = "300"
-  records = ["${aws_instance.openvpn.public_ip}"]
+  zone_id = var.route_zone_id
+  name = "app.${var.route_zone_name}"
+  type = "A"
+  ttl = "300"
+  records = [aws_instance.openvpn.public_ip]
 }
 
-output "private_ip"  { value = "${aws_instance.openvpn.private_ip}" }
-output "public_ip"   { value = "${aws_instance.openvpn.public_ip}" }
-output "public_fqdn" { value = "${aws_route53_record.openvpn.fqdn}" }
+output "private_ip" {
+  value = aws_instance.openvpn.private_ip
+}
+
+output "public_ip" {
+  value = aws_instance.openvpn.public_ip
+}
+
+output "public_fqdn" {
+  value = aws_route53_record.openvpn.fqdn
+}

--- a/openvpn/main.tf
+++ b/openvpn/main.tf
@@ -21,9 +21,7 @@ variable "ssl_key" {}
 
 variable "ssh_username" {}
 
-variable "ami" {
-  default = "ami-5fe36434"
-}
+variable "ami" {}
 
 variable "instance_type" {}
 

--- a/openvpn/versions.tf
+++ b/openvpn/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This upgrades all modules to be compatible with terraform 0.12.

We should not merge this until 100% of our repositories that depend on these modules have been upgraded to terraform 0.12. Until then, the ones we upgrade can just point at this branch.

Most of these changes were made by running the automated `terraform 0.12upgrade` tool.