### PR TITLE
Include region on policies and attachments name

### DIFF
--- a/iam_policy_cloudwatch/main.tf
+++ b/iam_policy_cloudwatch/main.tf
@@ -1,14 +1,18 @@
 # role names as string separated by ','
 variable "roles" {}
 
-variable "region" {}
+variable "region" { default = "" }
 
 variable "env" {}
 
 variable "app" {}
 
+locals {
+  region_prefix = var.region != "" ? "-${var.region}" : ""
+}
+
 resource "aws_iam_policy" "manage_cloudwatch" {
-  name = "${var.app}-${var.region}-${var.env}-manage-cloudwatch"
+  name = "${var.app}${local.region_prefix}-${var.env}-manage-cloudwatch"
   policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -33,7 +37,7 @@ POLICY
 }
 
 resource "aws_iam_policy_attachment" "manage_cloudwatch" {
-  name = "${var.app}-${var.region}-${var.env}-manage-cloudwatch"
+  name = "${var.app}${local.region_prefix}-${var.env}-manage-cloudwatch"
   roles = split(",", var.roles)
   policy_arn = aws_iam_policy.manage_cloudwatch.arn
 }

--- a/iam_policy_cloudwatch/main.tf
+++ b/iam_policy_cloudwatch/main.tf
@@ -1,12 +1,14 @@
 # role names as string separated by ','
 variable "roles" {}
 
+variable "region" {}
+
 variable "env" {}
 
 variable "app" {}
 
 resource "aws_iam_policy" "manage_cloudwatch" {
-  name = "${var.app}-${var.env}-manage-cloudwatch"
+  name = "${var.app}-${var.region}-${var.env}-manage-cloudwatch"
   policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -31,7 +33,7 @@ POLICY
 }
 
 resource "aws_iam_policy_attachment" "manage_cloudwatch" {
-  name = "${var.app}-${var.env}-manage-cloudwatch"
+  name = "${var.app}-${var.region}-${var.env}-manage-cloudwatch"
   roles = split(",", var.roles)
   policy_arn = aws_iam_policy.manage_cloudwatch.arn
 }

--- a/iam_policy_describe_ec2/main.tf
+++ b/iam_policy_describe_ec2/main.tf
@@ -1,14 +1,18 @@
 # role names as string separated by ','
 variable "roles" {}
 
-variable "region" {}
+variable "region" { default = "" }
 
 variable "env" {}
 
 variable "app" {}
 
+locals {
+  region_prefix = var.region != "" ? "-${var.region}" : ""
+}
+
 resource "aws_iam_policy" "describe_ec2" {
-  name = "${var.app}-${var.region}-${var.env}-describe-ec2"
+  name = "${var.app}${local.region_prefix}-${var.env}-describe-ec2"
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -31,7 +35,7 @@ POLICY
 }
 
 resource "aws_iam_policy_attachment" "describe_ec2" {
-  name = "${var.app}-${var.region}-${var.env}-describe-ec2"
+  name = "${var.app}${local.region_prefix}-${var.env}-describe-ec2"
   roles = split(",", var.roles)
   policy_arn = aws_iam_policy.describe_ec2.arn
 }

--- a/iam_policy_describe_ec2/main.tf
+++ b/iam_policy_describe_ec2/main.tf
@@ -1,12 +1,14 @@
 # role names as string separated by ','
 variable "roles" {}
 
+variable "region" {}
+
 variable "env" {}
 
 variable "app" {}
 
 resource "aws_iam_policy" "describe_ec2" {
-  name = "${var.app}-${var.env}-describe-ec2"
+  name = "${var.app}-${var.region}-${var.env}-describe-ec2"
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -29,7 +31,7 @@ POLICY
 }
 
 resource "aws_iam_policy_attachment" "describe_ec2" {
-  name = "${var.app}-${var.env}-describe-ec2"
+  name = "${var.app}-${var.region}-${var.env}-describe-ec2"
   roles = split(",", var.roles)
   policy_arn = aws_iam_policy.describe_ec2.arn
 }


### PR DESCRIPTION
Policies and their attachments must have unique names globally, this PR adds a new `region` parameter's value to the names.
On a future improvement, we can likely use the `region` to scope the permissions to only apply to resource on the given AWS region.