### PR TITLE
Update cloudwatch alarms for ALB healthy host counts

### DIFF
--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -8,6 +8,8 @@ variable "targets_name" {}
 
 variable "server_min_instances" {}
 
+variable "server_min_healthy_hosts" {}
+
 variable "sns_monitoring_topic_arn" {}
 
 variable "low_priority_sns_monitoring_topic_arn" {}
@@ -46,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = var.server_min_instances < 8 ? var.server_min_instances - 1 : ceil(var.server_min_instances * 3 / 4)
+  threshold = var.server_min_healthy_hosts
   unit = "Count"
   period = "60"
   statistic = "Average"
@@ -65,8 +67,8 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_too_high" {
     "TargetGroup" = var.target_group_dimension_id
   }
   metric_name = "UnHealthyHostCount"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold = var.server_min_instances < 8 ? 1 : floor(var.server_min_instances * 1 / 4)
+  comparison_operator = "GreaterThanThreshold"
+  threshold = var.server_min_instances - var.server_min_healthy_hosts
   unit = "Count"
   period = "60"
   statistic = "Average"

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -10,6 +10,8 @@ variable "server_min_instances" {}
 
 variable "server_min_healthy_hosts" {}
 
+variable "server_max_unhealthy_hosts" {}
+
 variable "sns_monitoring_topic_arn" {}
 
 variable "low_priority_sns_monitoring_topic_arn" {}
@@ -68,7 +70,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_too_high" {
   }
   metric_name = "UnHealthyHostCount"
   comparison_operator = "GreaterThanThreshold"
-  threshold = var.server_min_instances - var.server_min_healthy_hosts
+  threshold = var.server_max_unhealthy_hosts
   unit = "Count"
   period = "60"
   statistic = "Average"

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -49,14 +49,14 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   insufficient_data_actions = []
 
   metric_query {
-    id          = "p1"
-    expression  = "h1 / (h1 + h2)"
+    id          = "healthy_proportion"
+    expression  = "healthy_count / (healthy_count + unhealthy_count)"
     label       = "HealthyHostProportion"
     return_data = "true"
   }
 
   metric_query {
-    id          = "h1"
+    id          = "healthy_count"
     metric {
       metric_name = "HealthyHostCount"
       namespace   = "AWS/ApplicationELB"
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   }
 
   metric_query {
-    id          = "h2"
+    id          = "unhealthy_count"
     metric {
       metric_name = "UnHealthyHostCount"
       namespace   = "AWS/ApplicationELB"

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -8,9 +8,7 @@ variable "targets_name" {}
 
 variable "server_min_instances" {}
 
-variable "server_min_healthy_hosts" {}
-
-variable "server_max_unhealthy_hosts" {}
+variable "server_min_healthy_proportion" {}
 
 variable "sns_monitoring_topic_arn" {}
 
@@ -44,7 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   alarm_name = "${var.app_environment}:alb:public:${var.targets_name} Healthy Hosts: Severe Deficiency"
   alarm_description = "Significantly less than the desired proportion of healthy ${var.targets_name} hosts behind the ALB"
   comparison_operator = "LessThanThreshold"
-  threshold = ".75"
+  threshold = var.server_min_healthy_proportion
   evaluation_periods = "3"
   alarm_actions = [var.sns_monitoring_topic_arn]
   ok_actions = [var.sns_monitoring_topic_arn]


### PR DESCRIPTION
Change the alarm `healthy_hosts_seriously_low` to be triggered when proportion of `healthy / (healthy + unhealthy)` is below a threshold (which is an input into the module)

The consumer should configure this threshold such that it will not be hit by the deployment process