### PR TITLE
Update app server healthy-host alarms, use counts + add unhealthy-host alarm

### DIFF
--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -43,8 +43,8 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   metric_name = "UnHealthyHostCount"
   statistic = "Average"
   unit = "Count"
-  comparison_operator = "GreaterThanThreshold"
-  threshold = "0"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold = "1"
   period = "60"
   evaluation_periods = "3"
 

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -8,6 +8,8 @@ variable "targets_name" {}
 
 variable "server_min_instances" {}
 
+variable "server_min_healthy" {}
+
 variable "sns_monitoring_topic_arn" {}
 
 variable "low_priority_sns_monitoring_topic_arn" {}
@@ -37,13 +39,33 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_low_too_long" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
-  alarm_name = "${var.app_environment}:alb:public:${var.targets_name} Unhealthy Hosts: At least one"
-  alarm_description = "At least one unhealthy host in ${var.targets_name} behind the ALB. This should not be triggered by normal autoscaling and deployment"
+  alarm_name = "${var.app_environment}:alb:public:${var.targets_name} Healthy Hosts: Severe Deficiency"
+  alarm_description = "Significantly less than the desired number of healthy ${var.targets_name} hosts behind the ALB"
+  namespace = "AWS/ApplicationELB"
+  dimensions = {
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
+  }
+  metric_name = "HealthyHostCount"
+  comparison_operator = "LessThanThreshold"
+  threshold = var.server_min_healthy
+  unit = "Count"
+  period = "60"
+  statistic = "Average"
+  evaluation_periods = "3"
+  alarm_actions = [var.sns_monitoring_topic_arn]
+  ok_actions = [var.sns_monitoring_topic_arn]
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_too_many_too_long" {
+  alarm_name = "${var.app_environment}:alb:public:${var.targets_name} Unhealthy Hosts: Too many"
+  alarm_description = "Too many unhealthy hosts in ${var.targets_name} behind the ALB. This should not be triggered by normal autoscaling and deployment"
 
   metric_name = "UnHealthyHostCount"
   statistic = "Average"
   unit = "Count"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = "GreaterThanThreshold"
   threshold = "1"
   period = "60"
   evaluation_periods = "3"

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -61,23 +61,23 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
 resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_too_many_too_long" {
   alarm_name = "${var.app_environment}:alb:public:${var.targets_name} Unhealthy Hosts: Too many"
   alarm_description = "Too many unhealthy hosts in ${var.targets_name} behind the ALB. This should not be triggered by normal autoscaling and deployment"
+  namespace = "AWS/ApplicationELB"
+  dimensions = {
+    "LoadBalancer" = var.alb_dimension_id
+    "TargetGroup" = var.target_group_dimension_id
+  }
 
   metric_name = "UnHealthyHostCount"
-  statistic = "Average"
-  unit = "Count"
   comparison_operator = "GreaterThanThreshold"
   threshold = "1"
+  unit = "Count"
   period = "60"
+  statistic = "Average"
   evaluation_periods = "3"
 
   alarm_actions = [var.sns_monitoring_topic_arn]
   ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []
-
-  dimensions = {
-    "LoadBalancer" = var.alb_dimension_id
-    "TargetGroup" = var.target_group_dimension_id
-  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_response_time" {

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -41,10 +41,13 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   alarm_description = "At least one unhealthy host in ${var.targets_name} behind the ALB. This should not be triggered by normal autoscaling and deployment"
 
   metric_name = "UnHealthyHostCount"
+  statistic = "Average"
+  unit = "Count"
   comparison_operator = "GreaterThanThreshold"
   threshold = "0"
-
+  period = "60"
   evaluation_periods = "3"
+
   alarm_actions = [var.sns_monitoring_topic_arn]
   ok_actions = [var.sns_monitoring_topic_arn]
   insufficient_data_actions = []

--- a/cloudwatch_alb_target_group/main.tf
+++ b/cloudwatch_alb_target_group/main.tf
@@ -8,7 +8,7 @@ variable "targets_name" {}
 
 variable "server_min_instances" {}
 
-variable "server_min_healthy" {}
+variable "server_min_healthy_instances" {}
 
 variable "sns_monitoring_topic_arn" {}
 
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_seriously_low" {
   }
   metric_name = "HealthyHostCount"
   comparison_operator = "LessThanThreshold"
-  threshold = var.server_min_healthy
+  threshold = var.server_min_healthy_instances
   unit = "Count"
   period = "60"
   statistic = "Average"


### PR DESCRIPTION
1. Add back the healthy-host count alarm (short duration, "severe" low number of healthy hosts) but make it parametrized what the count threshold is so that we can avoid triggering it for the deployment strategy
2. Add an alarm for unhealthy-host count. "unhealthy-host" should not happen during normal deployment or autoscaling